### PR TITLE
Add support for highlighting Scheme in markdown file's fenced code block

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,13 @@
                 "language": "scheme",
                 "scopeName": "source.scheme",
                 "path": "./syntaxes/scheme.tmLanguage"
+            },
+            {
+                "scopeName": "markdown.scheme.codeblock",
+                "path": "./syntaxes/scheme.markdown.tmLanguage.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ]
             }
         ],
         "snippets": [

--- a/syntaxes/scheme.markdown.tmLanguage.json
+++ b/syntaxes/scheme.markdown.tmLanguage.json
@@ -1,0 +1,22 @@
+{
+    "fileTypes": [],
+    "injectionSelector": "L:text.html.markdown",
+    "patterns": [
+        {
+            "include": "#fenced_code_block_scheme"
+        }
+    ],
+    "repository": {
+        "fenced_code_block_scheme": {
+            "begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(scheme)(\\s+[^`~]*)?$)",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "contentName": "meta.embedded.block.scheme",
+            "patterns": [
+                {
+                    "include": "source.scheme"
+                }
+            ]
+        }
+    },
+    "scopeName": "markdown.scheme.codeblock"
+}


### PR DESCRIPTION
Using this **[example](https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example)**.

### Before
![image](https://user-images.githubusercontent.com/4580163/49641631-ae62c580-fa4b-11e8-9ec7-fcf33934acfd.png)

### After
![image](https://user-images.githubusercontent.com/4580163/49641640-b6bb0080-fa4b-11e8-9274-4e9aae7d3725.png)

### Notice

Only support `scheme`, other extensions like `scm` `sch` `ss` `rkt`, won't highlight when previewing markdown.