### PR TITLE
Fix error in which extension fails to start up

### DIFF
--- a/src/schemeConfiguration.ts
+++ b/src/schemeConfiguration.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 export const configuration: vscode.LanguageConfiguration = {
     wordPattern: /[\w\-\.:<>\*][\w\d\.\\/\-\?<>\*!]+/,
     indentationRules: {
-        decreaseIndentPattern: undefined,
+        decreaseIndentPattern: /$a/, // match nothing: https://stackoverflow.com/questions/1723182/a-regex-that-will-never-be-matched-by-anything
         increaseIndentPattern: /^\s*\(.*[^)]\s*$/
     }
 }


### PR DESCRIPTION
## Bug
Running this extension via opening a Scheme file gives 
![image](https://user-images.githubusercontent.com/33488131/111891083-b7db8600-89e7-11eb-8643-780084559cc5.png)
and in dev console
![image](https://user-images.githubusercontent.com/33488131/111891086-bf029400-89e7-11eb-9aca-ab5a11e1beea.png)

This is because VSCode does `RegExp.source` at some point during initialisation. Replacing `undefined` with `null` reproduces the above error but with `null` in place of `undefined`.

`decreaseIndentPattern` should not be `undefined`: https://code.visualstudio.com/api/references/vscode-api#IndentationRule


## Fix
Use a RegExp that matches nothing: `/$a/` instead of `undefined`.

